### PR TITLE
Fix off by one error in AsperiteTag::frames

### DIFF
--- a/src/computed.rs
+++ b/src/computed.rs
@@ -127,7 +127,7 @@ impl Aseprite {
                             (
                                 raw_tag.name.clone(),
                                 AsepriteTag {
-                                    frames: raw_tag.from..raw_tag.to,
+                                    frames: raw_tag.from..raw_tag.to + 1,
                                     animation_direction: raw_tag.anim_direction,
                                     name: raw_tag.name,
                                 },


### PR DESCRIPTION
`Range` is non-inclusive and therefore the `end` needs to be `+1`.

Maybe it makes sense to replace this by `RangeInclusive` or a different data type altogether.

For the time being this fixes the last frame of the animation always being skipped.